### PR TITLE
Fix spelling (succeded → succeeded)

### DIFF
--- a/renderers/simple.go
+++ b/renderers/simple.go
@@ -61,7 +61,7 @@ func (r SimpleRenderer) RenderScopeFinished(entry *echelon.LogScopeFinished) {
 	formatedDuration := utils.FormatDuration(duration, true)
 	lastScope := scopes[level-1]
 	if entry.Success() {
-		message := fmt.Sprintf("'%s' succeded in %s!", lastScope, formatedDuration)
+		message := fmt.Sprintf("'%s' succeeded in %s!", lastScope, formatedDuration)
 		coloredMessage := terminal.GetColoredText(r.colors.SuccessColor, message)
 		r.renderEntry(coloredMessage)
 	} else {


### PR DESCRIPTION
This typo makes impossible to write tests in projects that use https://github.com/client9/misspell linter and check for scope statuses.