### PR TITLE
flush buffer when stopping renderer

### DIFF
--- a/renderers/interactive.go
+++ b/renderers/interactive.go
@@ -83,6 +83,7 @@ func (r *InteractiveRenderer) StopDrawing() {
 	r.DrawFrame()
 	// don't leave autowrap disabled in the terminal
 	_, _ = r.out.WriteString(enableAutoWrap)
+	_ = r.out.Flush()
 }
 
 func (r *InteractiveRenderer) DrawFrame() {


### PR DESCRIPTION
Otherwise the last few bytes might not get written. The last fix https://github.com/cirruslabs/echelon/pull/12 didn't always work because the buffer might not get flushed before exiting.