### PR TITLE
Use lock only for public methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,8 @@ linters:
     - goimports
     - funlen
 
+    # That's fine that some Proto objects don't have all fields initialized
+    - exhaustivestruct
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.
   max-issues-per-linter: 0

--- a/renderers/internal/node/echelone_node.go
+++ b/renderers/internal/node/echelone_node.go
@@ -97,10 +97,10 @@ func (node *EchelonNode) DescriptionLength() int {
 }
 
 func (node *EchelonNode) Render() []string {
-	title := node.fancyTitle()
-	tail := node.renderChildren()
 	node.lock.RLock()
 	defer node.lock.RUnlock()
+	title := node.fancyTitle()
+	tail := node.renderChildren()
 	if len(node.description) > node.visibleDescriptionLines && node.visibleDescriptionLines >= 0 {
 		tail = append(tail, "...")
 		tail = append(tail, node.description[(len(node.description)-node.visibleDescriptionLines):]...)
@@ -121,8 +121,6 @@ func (node *EchelonNode) Render() []string {
 }
 
 func (node *EchelonNode) renderChildren() []string {
-	node.lock.RLock()
-	defer node.lock.RUnlock()
 	var result []string
 	for _, child := range node.children {
 		result = append(result, child.Render()...)
@@ -131,11 +129,8 @@ func (node *EchelonNode) renderChildren() []string {
 }
 
 func (node *EchelonNode) fancyTitle() string {
-	duration := utils.FormatDuration(node.ExecutionDuration(), len(node.children) == 0)
-	isRunning := node.IsRunning()
-
-	node.lock.RLock()
-	defer node.lock.RUnlock()
+	duration := utils.FormatDuration(node.executionDuration(), len(node.children) == 0)
+	isRunning := node.isRunning()
 	prefix := node.status
 	if isRunning {
 		prefix = node.config.CurrentProgressIndicatorFrame()
@@ -150,6 +145,10 @@ func (node *EchelonNode) fancyTitle() string {
 func (node *EchelonNode) ExecutionDuration() time.Duration {
 	node.lock.RLock()
 	defer node.lock.RUnlock()
+	return node.executionDuration()
+}
+
+func (node *EchelonNode) executionDuration() time.Duration {
 	if !node.startTime.IsZero() && node.endTime.IsZero() {
 		return time.Since(node.startTime)
 	}
@@ -171,6 +170,10 @@ func (node *EchelonNode) HasCompleted() bool {
 func (node *EchelonNode) IsRunning() bool {
 	node.lock.RLock()
 	defer node.lock.RUnlock()
+	return node.isRunning()
+}
+
+func (node *EchelonNode) isRunning() bool {
 	return !node.startTime.IsZero() && node.endTime.IsZero()
 }
 

--- a/renderers/simple_test.go
+++ b/renderers/simple_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func Test_quotedIfNeeded(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "'foo'", quotedIfNeeded("foo"))
 
 	assert.Equal(t, "task 'foo'", quotedIfNeeded("task 'foo'"))

--- a/terminal/incremental_test.go
+++ b/terminal/incremental_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Test_calculateIncrementalUpdate_SameTwoLines(t *testing.T) {
+	t.Parallel()
 	var result bytes.Buffer
 	terminal.CalculateIncrementalUpdate(
 		bufio.NewWriter(&result),
@@ -19,6 +20,7 @@ func Test_calculateIncrementalUpdate_SameTwoLines(t *testing.T) {
 }
 
 func Test_calculateIncrementalUpdate_AddSingleLine(t *testing.T) {
+	t.Parallel()
 	var result bytes.Buffer
 	terminal.CalculateIncrementalUpdate(
 		bufio.NewWriter(&result),
@@ -29,6 +31,7 @@ func Test_calculateIncrementalUpdate_AddSingleLine(t *testing.T) {
 }
 
 func Test_calculateIncrementalUpdate_InplaceChange(t *testing.T) {
+	t.Parallel()
 	var result bytes.Buffer
 	terminal.CalculateIncrementalUpdate(
 		bufio.NewWriter(&result),


### PR DESCRIPTION
Since it's not allowed to recursively use `RWMutex` let's make a contract that only public methods can acquire it and private methods can't use it.

Fixes race in #14