### PR TITLE
Add disable color for simple renderer

### DIFF
--- a/renderers/simple.go
+++ b/renderers/simple.go
@@ -2,13 +2,14 @@ package renderers
 
 import (
 	"fmt"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/cirruslabs/echelon"
 	"github.com/cirruslabs/echelon/renderers/internal/console"
 	"github.com/cirruslabs/echelon/terminal"
 	"github.com/cirruslabs/echelon/utils"
-	"io"
-	"strings"
-	"time"
 )
 
 type SimpleRenderer struct {
@@ -68,7 +69,7 @@ func (r SimpleRenderer) RenderScopeFinished(entry *echelon.LogScopeFinished) {
 		r.renderEntry(coloredMessage)
 	case echelon.FinishTypeFailed:
 		message := fmt.Sprintf("%s failed in %s!", quotedIfNeeded(lastScope), formatedDuration)
-		coloredMessage := terminal.GetColoredText(r.colors.NeutralColor, message)
+		coloredMessage := terminal.GetColoredText(r.colors.FailureColor, message)
 		r.renderEntry(coloredMessage)
 	case echelon.FinishTypeSkipped:
 		message := fmt.Sprintf("%s skipped in %s!", quotedIfNeeded(lastScope), formatedDuration)

--- a/terminal/color.go
+++ b/terminal/color.go
@@ -11,6 +11,8 @@ type ColorSchema struct {
 // Reset ANSI sequence.
 const ResetSequence = "\033[0m"
 
+const NoColor = -1
+
 const (
 	BlackColor = iota
 	RedColor
@@ -30,7 +32,19 @@ func DefaultColorSchema() *ColorSchema {
 	}
 }
 
+func NoColorSchema() *ColorSchema {
+	return &ColorSchema{
+		SuccessColor: NoColor,
+		FailureColor: NoColor,
+		NeutralColor: NoColor,
+	}
+}
+
 func GetColoredText(color int, text string) string {
+	if color == NoColor {
+		return text
+	}
+
 	return fmt.Sprintf("%s%s%s", GetColorSequence(color), text, ResetSequence)
 }
 


### PR DESCRIPTION
### Changes
- ~Add new func `NewSimpleRendererWithoutColor`~
- Add new color schema `NoColorSchema()`
- Change `FinishTypeFailed` color from `NeutralColor` to `FailureColor` (if this intended, I will change this back)

### Reason
Using current `NewSimpleRenderer`, if we pipe or log it to file it will print the ANSI color codes.
![image](https://user-images.githubusercontent.com/11629676/126192943-b088ef05-b7ff-4fc7-b942-bbb271a0a896.png)

So for my use case, I want to use `NewInteractiveRenderer` in my development and use `NewSimpleRenderer` in the production but it will print ANSI color codes in the log.

~Here is the result if we use `NewSimpleRendererWithoutColor`.~
Now we can use it like this
```
import (
	"github.com/cirruslabs/echelon/renderers"
	"github.com/cirruslabs/echelon/terminal"
)

renderers.NewSimpleRenderer(os.Stdout, terminal.NoColorSchema())
```
![image](https://user-images.githubusercontent.com/11629676/126193357-c7790b07-f740-4100-b358-717cfb1afec6.png)

Thank you