### PR TITLE
Introduce DescriptionLinesWhenSkipped

### DIFF
--- a/renderers/config/interactive_config.go
+++ b/renderers/config/interactive_config.go
@@ -17,6 +17,7 @@ type InteractiveRendererConfig struct {
 	FailureStatus                  string
 	SkippedStatus                  string
 	DescriptionLinesWhenFailed     int
+	DescriptionLinesWhenSkipped    int
 	VisibleDescriptionLines        int
 }
 
@@ -40,6 +41,7 @@ func NewDefaultEmojiRenderingConfig() *InteractiveRendererConfig {
 		FailureStatus:                  "❌",
 		SkippedStatus:                  "⏩",
 		DescriptionLinesWhenFailed:     100,
+		DescriptionLinesWhenSkipped:    0,
 		VisibleDescriptionLines:        defaultVisibleLines,
 	}
 }
@@ -57,6 +59,7 @@ func NewDefaultSymbolsOnlyRenderingConfig() *InteractiveRendererConfig {
 		FailureStatus:                  "-",
 		SkippedStatus:                  "!",
 		DescriptionLinesWhenFailed:     100,
+		DescriptionLinesWhenSkipped:    0,
 	}
 }
 

--- a/renderers/interactive.go
+++ b/renderers/interactive.go
@@ -65,7 +65,9 @@ func (r *InteractiveRenderer) RenderScopeFinished(entry *echelon.LogScopeFinishe
 		n.SetVisibleDescriptionLines(r.config.DescriptionLinesWhenFailed)
 		n.CompleteWithColor(r.config.FailureStatus, r.config.Colors.FailureColor)
 	case echelon.FinishTypeSkipped:
-		if n != r.rootNode {
+		if r.config.DescriptionLinesWhenSkipped != 0 {
+			n.SetVisibleDescriptionLines(r.config.DescriptionLinesWhenSkipped)
+		} else if n != r.rootNode {
 			n.ClearAllChildren()
 			n.ClearDescription()
 		}


### PR DESCRIPTION
This allows users to configure the echelon to output some log details when the scope was skipped.